### PR TITLE
code fixes and add GitHub CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+
+jobs:
+  linux-x86_64:
+    name: Linux x86-64 (musl static)
+    runs-on: ubuntu-latest
+    container: alpine:3.21
+    steps:
+      - name: Install build dependencies
+        run: apk add --no-cache build-base ncurses-dev ncurses-static git
+      - uses: actions/checkout@v4
+      - name: Build
+        run: sh ci/build-linux-musl.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fed-linux-x86_64
+          path: build/linux-x86_64/fed
+
+  windows-x86_64:
+    name: Windows x86-64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install MinGW cross-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64
+      - name: Build
+        run: ci/build-win64.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fed-windows-x86_64
+          path: build/win64/fed.exe
+
+  msdos:
+    name: MS-DOS (DJGPP)
+    runs-on: ubuntu-latest
+    env:
+      # https://github.com/andrewwutw/build-djgpp/releases
+      DJGPP_ARCHIVE: djgpp-linux64-gcc1220.tar.bz2
+      DJGPP_URL: https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download DJGPP cross-compiler
+        run: |
+          curl -fsSL "$DJGPP_URL" | sudo tar xjf - -C /usr/local
+          echo "/usr/local/djgpp/bin" >> "$GITHUB_PATH"
+      - name: Build
+        run: ci/build-dos-djgpp.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fed-msdos
+          path: build/dos/fed.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-*.o
+# ignore editor junk
 *~
-*.exe
-help.c
+.*.swp
+
+# ignore build artifacts
+*.o
+/fed
+/fed.exe
+/help.c
+/makehelp
+/build/

--- a/ci/build-dos-djgpp.sh
+++ b/ci/build-dos-djgpp.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Cross-compile an MS-DOS binary using DJGPP.
+#
+# Toolchain requirements:
+#   - DJGPP cross-compiler (e.g. from github.com/andrewwutw/build-djgpp)
+#
+# Environment variables:
+#   CROSS    - toolchain prefix        (default: i586-pc-msdosdjgpp-)
+#   CC       - target C compiler       (default: ${CROSS}gcc)
+#   HOSTCC   - host C compiler         (default: gcc)
+#   BUILDDIR - output directory        (default: build/dos)
+set -e
+
+CROSS="${CROSS:-i586-pc-msdosdjgpp-}"
+CC="${CC:-${CROSS}gcc}"
+HOSTCC="${HOSTCC:-gcc}"
+BUILDDIR="${BUILDDIR:-build/dos}"
+
+command -v "$CC" >/dev/null 2>&1 || { echo "error: $CC not found" >&2; exit 1; }
+command -v "$HOSTCC" >/dev/null 2>&1 || { echo "error: $HOSTCC (host compiler) not found" >&2; exit 1; }
+
+mkdir -p "$BUILDDIR"
+
+"$HOSTCC" -Wall -O2 -o "$BUILDDIR/makehelp" makehelp.c
+"$BUILDDIR/makehelp" help.txt "$BUILDDIR/help.c"
+
+CFLAGS="-DTARGET_DJGPP -I. -Wall -O3 -fomit-frame-pointer"
+SRCS="buffer.c config.c dialog.c disp.c fed.c gui.c help.c kill.c
+      line.c menu.c misc.c search.c tetris.c util.c iodjgpp.c"
+
+for src in $SRCS; do
+	obj="$BUILDDIR/${src%.c}.o"
+	case "$src" in
+		help.c) "$CC" $CFLAGS -c "$BUILDDIR/help.c" -o "$obj" ;;
+		*)      "$CC" $CFLAGS -c "$src" -o "$obj" ;;
+	esac
+done
+
+OBJS=""
+for src in $SRCS; do
+	OBJS="$OBJS $BUILDDIR/${src%.c}.o"
+done
+
+"$CC" -s -o "$BUILDDIR/fed.exe" $OBJS
+
+echo "Built: $BUILDDIR/fed.exe"

--- a/ci/build-linux-musl.sh
+++ b/ci/build-linux-musl.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Build a static Linux x86-64 binary using musl libc + ncurses.
+#
+# Toolchain requirements:
+#   - C compiler targeting musl (gcc on Alpine, or musl-gcc on glibc distros)
+#   - ncurses static library and headers available to the compiler
+#
+# Environment variables:
+#   CC           - target C compiler      (default: gcc)
+#   HOSTCC       - host C compiler         (default: gcc)
+#   BUILDDIR     - output directory        (default: build/linux-x86_64)
+#   NCURSES_LIBS - ncurses link flags      (auto-detected via pkg-config)
+set -e
+
+CC="${CC:-gcc}"
+HOSTCC="${HOSTCC:-gcc}"
+BUILDDIR="${BUILDDIR:-build/linux-x86_64}"
+
+command -v "$CC" >/dev/null 2>&1 || { echo "error: $CC not found" >&2; exit 1; }
+command -v "$HOSTCC" >/dev/null 2>&1 || { echo "error: $HOSTCC (host compiler) not found" >&2; exit 1; }
+
+if ! echo '#include <curses.h>' | "$CC" -E -x c - >/dev/null 2>&1; then
+	echo "error: ncurses headers not found for $CC" >&2
+	exit 1
+fi
+
+if [ -z "$NCURSES_LIBS" ]; then
+	if command -v pkg-config >/dev/null 2>&1; then
+		NCURSES_LIBS="$(pkg-config --static --libs ncurses 2>/dev/null)" || true
+	fi
+	NCURSES_LIBS="${NCURSES_LIBS:--lncurses}"
+fi
+
+mkdir -p "$BUILDDIR"
+
+"$HOSTCC" -Wall -O2 -o "$BUILDDIR/makehelp" makehelp.c
+"$BUILDDIR/makehelp" help.txt "$BUILDDIR/help.c"
+
+CFLAGS="-DTARGET_CURSES -I. -Wall -O3 -fomit-frame-pointer"
+SRCS="buffer.c config.c dialog.c disp.c fed.c gui.c help.c kill.c
+      line.c menu.c misc.c search.c tetris.c util.c iocurses.c"
+
+for src in $SRCS; do
+	obj="$BUILDDIR/${src%.c}.o"
+	case "$src" in
+		help.c) "$CC" $CFLAGS -c "$BUILDDIR/help.c" -o "$obj" ;;
+		*)      "$CC" $CFLAGS -c "$src" -o "$obj" ;;
+	esac
+done
+
+OBJS=""
+for src in $SRCS; do
+	OBJS="$OBJS $BUILDDIR/${src%.c}.o"
+done
+
+"$CC" -static -s -o "$BUILDDIR/fed" $OBJS $NCURSES_LIBS
+
+echo "Built: $BUILDDIR/fed"

--- a/ci/build-win64.sh
+++ b/ci/build-win64.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Cross-compile a Windows x86-64 binary using MinGW.
+#
+# Toolchain requirements:
+#   - x86_64-w64-mingw32-gcc (and optionally windres for icons)
+#
+# Environment variables:
+#   CROSS    - toolchain prefix        (default: x86_64-w64-mingw32-)
+#   CC       - target C compiler       (default: ${CROSS}gcc)
+#   WINDRES  - resource compiler       (default: ${CROSS}windres)
+#   HOSTCC   - host C compiler         (default: gcc)
+#   BUILDDIR - output directory        (default: build/win64)
+set -e
+
+CROSS="${CROSS:-x86_64-w64-mingw32-}"
+CC="${CC:-${CROSS}gcc}"
+WINDRES="${WINDRES:-${CROSS}windres}"
+HOSTCC="${HOSTCC:-gcc}"
+BUILDDIR="${BUILDDIR:-build/win64}"
+
+command -v "$CC" >/dev/null 2>&1 || { echo "error: $CC not found" >&2; exit 1; }
+command -v "$HOSTCC" >/dev/null 2>&1 || { echo "error: $HOSTCC (host compiler) not found" >&2; exit 1; }
+
+mkdir -p "$BUILDDIR"
+
+"$HOSTCC" -Wall -O2 -o "$BUILDDIR/makehelp" makehelp.c
+"$BUILDDIR/makehelp" help.txt "$BUILDDIR/help.c"
+
+CFLAGS="-DTARGET_WIN -iquote . -Wall -O3 -fomit-frame-pointer"
+SRCS="buffer.c config.c dialog.c disp.c fed.c gui.c help.c kill.c
+      line.c menu.c misc.c search.c tetris.c util.c iowin.c"
+
+for src in $SRCS; do
+	obj="$BUILDDIR/${src%.c}.o"
+	case "$src" in
+		help.c) "$CC" $CFLAGS -c "$BUILDDIR/help.c" -o "$obj" ;;
+		*)      "$CC" $CFLAGS -c "$src" -o "$obj" ;;
+	esac
+done
+
+OBJS=""
+for src in $SRCS; do
+	OBJS="$OBJS $BUILDDIR/${src%.c}.o"
+done
+
+if command -v "$WINDRES" >/dev/null 2>&1 && [ -f fed.rc ]; then
+	"$WINDRES" fed.rc -o "$BUILDDIR/fed_res.o"
+	OBJS="$OBJS $BUILDDIR/fed_res.o"
+fi
+
+"$CC" -s -mwindows -o "$BUILDDIR/fed.exe" $OBJS \
+	-luser32 -lgdi32 -lshell32 -lwinmm -ladvapi32
+
+echo "Built: $BUILDDIR/fed.exe"

--- a/iocurses.c
+++ b/iocurses.c
@@ -173,12 +173,15 @@ void term_init(int screenheight)
       printf("\e[?35l\e[?1000h\e[21t");
       fflush(stdout);
 
+      wtimeout(stdscr, 200);
+
       i = 0;
 
       for (;;) {
-	 do {
-	    c = getch();
-	 } while (c == ERR);
+	 c = getch();
+
+	 if (c == ERR)
+	    break;
 
 	 orig_title[i] = c;
 
@@ -188,21 +191,28 @@ void term_init(int screenheight)
 	 i++;
       }
 
-      orig_title[i-1] = 0;
+      nodelay(stdscr, TRUE);
 
-      p = strstr(orig_title, "\e]l");
-
-      if (p) {
-	 p += 3;
-
-	 memmove(orig_title, p, strlen(p)+1);
-
-	 for (i=0; orig_title[i]; i++)
-	    if (orig_title[i] < ' ')
-	       orig_title[i] = ' ';
-      }
-      else
+      if (c == ERR) {
 	 orig_title[0] = 0;
+      }
+      else {
+	 orig_title[i-1] = 0;
+
+	 p = strstr(orig_title, "\e]l");
+
+	 if (p) {
+	    p += 3;
+
+	    memmove(orig_title, p, strlen(p)+1);
+
+	    for (i=0; orig_title[i]; i++)
+	       if (orig_title[i] < ' ')
+		  orig_title[i] = ' ';
+	 }
+	 else
+	    orig_title[0] = 0;
+      }
 
    }
 

--- a/iocurses.c
+++ b/iocurses.c
@@ -83,13 +83,21 @@ void curs_init(int r)
    nodelay(stdscr, TRUE);
 
    if (has_colors()) {
+      int limit;
+
       start_color();
 
-      for (i=1; i<COLOR_PAIRS; i++) {
-	 f = (i-1)%COLORS;
-	 b = (i-1)/COLORS;
+      /* 8 DOS palette colors = 64 pairs; use base-8 indexing so tattr()
+         and init_pair() agree regardless of terminal COLORS value */
+      limit = 64;
+      if (limit >= COLOR_PAIRS)
+	 limit = COLOR_PAIRS - 1;
 
-	 /* Linux console pallete isn't the same as in DOS */
+      for (i=1; i<=limit; i++) {
+	 f = (i-1) % 8;
+	 b = (i-1) / 8;
+
+	 /* remap DOS palette order to curses order */
 	 if (f == 1)
 	    f = 4;
 	 else if (f == 4)
@@ -98,8 +106,6 @@ void curs_init(int r)
 	    f = 6;
 	 else if (f == 6)
 	    f = 3;
-	 else
-	    f = f;
 
 	 if (b == 1)
 	    b = 4;
@@ -109,10 +115,8 @@ void curs_init(int r)
 	    b = 6;
 	 else if (b == 6)
 	    b = 3;
-	 else
-	    b = b;
 
-	 init_pair(i, f%COLORS, b%COLORS);
+	 init_pair(i, f, b);
       }
 
       got_color = TRUE;
@@ -757,7 +761,7 @@ void tattr(int col)
    if (got_color) {
       f = col&15;
       b = col>>4;
-      c = (((f&7) + (b&7)*COLORS) % (COLOR_PAIRS-1)) + 1;
+      c = (f&7) + (b&7)*8 + 1;
 
       cattrib |= COLOR_PAIR(c);
 

--- a/iocurses.c
+++ b/iocurses.c
@@ -21,7 +21,6 @@
 #include <sys/stat.h>
 #include <sys/times.h>
 #include <sys/ioctl.h>
-#include <sys/kd.h>
 
 #include "fed.h"
 

--- a/iodjgpp.c
+++ b/iodjgpp.c
@@ -342,7 +342,7 @@ void pch(unsigned char c)
 
 
 
-void mywrite(unsigned char *s)
+void mywrite(char *s)
 {
    int p;
 


### PR DESCRIPTION
Runs the three ci/ build scripts on push to master, tags, and pull requests. Installs toolchains (Alpine/musl, MinGW, DJGPP) and uploads build artifacts.

Standalone cross-compilation build scripts that check toolchain availability and compile FED for three targets:
- static Linux x86-64 (musl + ncurses)
- Windowsx86-64 (MinGW)
- MS-DOS (DJGPP)

Change mywrite() parameter from unsigned char * to char * in iodjgpp.c  to match the declaration in io.h. Add /makehelp and /build/ to .gitignore.

Fix curses color pairs colliding on 256-color terminals. On terminals where COLORS=256 and COLOR_PAIRS=256, the tattr() formula (f&7 + (b&7)*COLORS) % (COLOR_PAIRS-1) caused different DOS color attributes to map to the same ncurses pair index.

Fix terminal title query hanging on modern terminals. The xterm title query (\e[21t) in term_init() used a busy-wait loop that spun forever when the terminal set COLORTERM but did not respond to the query. Use wtimeout() to give the terminal 200ms to respond,then proceed without title save/restore.