### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches: [master]
-    tags: ['v*']
+    tags: ['rel/*']
   pull_request:
 
 jobs:
@@ -17,10 +17,56 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build
         run: sh ci/build-linux-musl.sh
+      - name: Package
+        run: sh ci/package-linux-x86_64.sh
       - uses: actions/upload-artifact@v4
         with:
           name: fed-linux-x86_64
-          path: build/linux-x86_64/fed
+          path: dist/fed-linux-x86_64.tar.gz
+
+  linux-arm64:
+    name: Linux ARM64 (musl static)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - name: Build and package in Alpine ARM64 container
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v "${{ github.workspace }}:/work" -w /work \
+            alpine:3.21 sh -c "
+              apk add --no-cache build-base ncurses-dev ncurses-static &&
+              sh ci/build-linux-arm64.sh &&
+              sh ci/package-linux-arm64.sh
+            "
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fed-linux-arm64
+          path: dist/fed-linux-arm64.tar.gz
+
+  linux-arm32:
+    name: Linux ARM32 (musl static)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm
+      - name: Build and package in Alpine ARM32 container
+        run: |
+          docker run --rm --platform linux/arm/v7 \
+            -v "${{ github.workspace }}:/work" -w /work \
+            alpine:3.21 sh -c "
+              apk add --no-cache build-base ncurses-dev ncurses-static &&
+              sh ci/build-linux-arm32.sh &&
+              sh ci/package-linux-arm32.sh
+            "
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fed-linux-arm32
+          path: dist/fed-linux-arm32.tar.gz
 
   windows-x86_64:
     name: Windows x86-64
@@ -33,10 +79,30 @@ jobs:
           sudo apt-get install -y gcc-mingw-w64-x86-64
       - name: Build
         run: ci/build-win64.sh
+      - name: Package
+        run: ci/package-win64.sh
       - uses: actions/upload-artifact@v4
         with:
           name: fed-windows-x86_64
-          path: build/win64/fed.exe
+          path: dist/fed-win64.zip
+
+  windows-x86:
+    name: Windows x86 (32-bit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install MinGW cross-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-i686
+      - name: Build
+        run: ci/build-win32.sh
+      - name: Package
+        run: ci/package-win32.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fed-windows-x86
+          path: dist/fed-win32.zip
 
   msdos:
     name: MS-DOS (DJGPP)
@@ -53,7 +119,37 @@ jobs:
           echo "/usr/local/djgpp/bin" >> "$GITHUB_PATH"
       - name: Build
         run: ci/build-dos-djgpp.sh
+      - name: Package
+        run: ci/package-dos.sh
       - uses: actions/upload-artifact@v4
         with:
           name: fed-msdos
-          path: build/dos/fed.exe
+          path: dist/fed-dos.zip
+
+  release:
+    name: Create release
+    if: startsWith(github.ref, 'refs/tags/release-')
+    needs: [linux-x86_64, linux-arm64, linux-arm32, windows-x86_64, windows-x86, msdos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#release-}"
+          gh release create "$TAG" \
+            --title "FED $VERSION" \
+            --generate-notes \
+            artifacts/fed-linux-x86_64/* \
+            artifacts/fed-linux-arm64/* \
+            artifacts/fed-linux-arm32/* \
+            artifacts/fed-windows-x86_64/* \
+            artifacts/fed-windows-x86/* \
+            artifacts/fed-msdos/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /help.c
 /makehelp
 /build/
+/dist/

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -1,0 +1,126 @@
+Building FED
+============
+
+FED can be built natively or cross-compiled from Linux for several
+targets. Each target has a build script in the ci/ directory and can
+also be built using the GNUmakefile.
+
+
+Native Linux Build
+------------------
+
+Install build dependencies and run make:
+
+  Debian/Ubuntu:
+    sudo apt-get install build-essential libncurses-dev
+
+  Alpine:
+    apk add build-base ncurses-dev
+
+  Fedora:
+    sudo dnf install gcc make ncurses-devel
+
+Then:
+
+    make
+
+The GNUmakefile auto-detects ncurses via pkg-config. You can override
+NCURSES_CFLAGS and NCURSES_LIBS if needed.
+
+Alternatively, use the CI build script:
+
+    sh ci/build-linux-musl.sh
+
+This produces a static musl binary (when built on Alpine or with
+musl-gcc) at build/linux-x86_64/fed.
+
+
+Cross-Compiling from Debian/Ubuntu
+----------------------------------
+
+All cross-compilation targets use scripts in ci/ that check for the
+required toolchain and exit with an error if it is missing.
+
+
+Windows (x86-64 and x86):
+
+  Install the MinGW-w64 toolchain:
+
+    sudo apt-get install mingw-w64-tools \
+      mingw-w64-{i686,x86-64}-dev \
+      {gcc,g++,binutils}-mingw-w64-{i686,x86-64}
+
+  Build:
+
+    sh ci/build-win64.sh          # -> build/win64/fed.exe
+    sh ci/build-win32.sh          # -> build/win32/fed.exe
+
+
+MS-DOS (DJGPP):
+
+  Install the DJGPP cross-compiler. Pre-built toolchains are available
+  from https://github.com/andrewwutw/build-djgpp/releases
+
+  Extract it and add the bin directory to your PATH:
+
+    curl -fsSL https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2 \
+      | sudo tar xjf - -C /usr/local
+    export PATH="/usr/local/djgpp/bin:$PATH"
+
+  Build:
+
+    sh ci/build-dos-djgpp.sh      # -> build/dos/fed.exe
+
+
+Linux ARM64 (aarch64) and ARM32 (armv7):
+
+  These scripts are designed to run natively inside an Alpine Linux
+  container for the target architecture, using QEMU for emulation on
+  x86-64 hosts.
+
+  With Docker and QEMU binfmt support installed:
+
+    # ARM64 (Raspberry Pi 3+)
+    docker run --rm --platform linux/arm64 \
+      -v "$(pwd):/work" -w /work alpine:3.21 sh -c "
+        apk add --no-cache build-base ncurses-dev ncurses-static &&
+        sh ci/build-linux-arm64.sh
+      "
+
+    # ARM32 (Raspberry Pi 2+)
+    docker run --rm --platform linux/arm/v7 \
+      -v "$(pwd):/work" -w /work alpine:3.21 sh -c "
+        apk add --no-cache build-base ncurses-dev ncurses-static &&
+        sh ci/build-linux-arm32.sh
+      "
+
+  Or build natively on a Raspberry Pi running Alpine:
+
+    apk add build-base ncurses-dev ncurses-static
+    sh ci/build-linux-arm64.sh    # -> build/linux-arm64/fed
+    sh ci/build-linux-arm32.sh    # -> build/linux-arm32/fed
+
+
+Packaging
+---------
+
+After building, create distributable archives with the corresponding
+package script:
+
+    sh ci/package-linux-x86_64.sh   # -> dist/fed-linux-x86_64.tar.gz
+    sh ci/package-linux-arm64.sh    # -> dist/fed-linux-arm64.tar.gz
+    sh ci/package-linux-arm32.sh    # -> dist/fed-linux-arm32.tar.gz
+    sh ci/package-win64.sh          # -> dist/fed-win64.zip
+    sh ci/package-win32.sh          # -> dist/fed-win32.zip
+    sh ci/package-dos.sh            # -> dist/fed-dos.zip
+
+Each archive contains the binary along with readme.txt, COPYING,
+help.txt, and fed.syn.
+
+
+Releases
+--------
+
+GitHub Actions builds all targets on every push to master. Tagged
+releases using CalVer (e.g. git tag release-2026.04.27) automatically
+create a GitHub Release with all platform archives attached.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,23 +23,24 @@ endif
 
 ifeq ($(TARGET),djgpp)
 fed$(EXE): CFLAGS += -DTARGET_DJGPP
-fed$(EXE): LDFLAGS +=
 else
 ifeq ($(TARGET),win)
 fed$(EXE): CFLAGS += -DTARGET_WIN
-fed$(EXE): LDFLAGS += user32.lib gdi32.lib shell32.lib winmm.lib advapi32.lib
+fed$(EXE): LDLIBS += user32.lib gdi32.lib shell32.lib winmm.lib advapi32.lib
 else
 ifeq ($(TARGET),curses)
-fed$(EXE): CFLAGS += -DTARGET_CURSES
+NCURSES_CFLAGS ?= $(shell pkg-config --cflags ncurses 2>/dev/null)
+NCURSES_LIBS ?= $(shell pkg-config --libs ncurses 2>/dev/null || echo -lncurses)
+fed$(EXE): CFLAGS += -DTARGET_CURSES $(NCURSES_CFLAGS)
 ifdef DJGPP
-fed$(EXE): LDFLAGS += -lcurso
+fed$(EXE): LDLIBS += -lcurso
 else
-fed$(EXE): LDFLAGS += -lncurses
+fed$(EXE): LDLIBS += $(NCURSES_LIBS)
 endif
 else
 ifeq ($(TARGET),alleg)
 fed$(EXE): CFLAGS += -DTARGET_ALLEG
-fed$(EXE): LDFLAGS += -lalleg
+fed$(EXE): LDLIBS += -lalleg
 else
 badtarget:
 	@echo Unknown compile target $(TARGET)! (expecting djgpp, curses, msvc, or alleg)

--- a/ci/build-linux-arm32.sh
+++ b/ci/build-linux-arm32.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Build a static Linux ARM32 binary with ncurses.
+# Runs natively on armv7l or cross-compiles using arm-linux-gnueabihf-gcc.
+#
+# Environment variables:
+#   CROSS        - toolchain prefix        (default: arm-linux-gnueabihf- when cross-compiling)
+#   CC           - target C compiler       (default: ${CROSS}gcc)
+#   HOSTCC       - host C compiler         (default: gcc)
+#   BUILDDIR     - output directory        (default: build/linux-arm32)
+#   NCURSES_LIBS - ncurses link flags      (auto-detected via pkg-config)
+set -e
+
+if [ "$(uname -m)" = "armv7l" ]; then
+	CROSS="${CROSS:-}"
+else
+	CROSS="${CROSS:-arm-linux-gnueabihf-}"
+fi
+CC="${CC:-${CROSS}gcc}"
+HOSTCC="${HOSTCC:-gcc}"
+BUILDDIR="${BUILDDIR:-build/linux-arm32}"
+
+command -v "$CC" >/dev/null 2>&1 || { echo "error: $CC not found" >&2; exit 1; }
+command -v "$HOSTCC" >/dev/null 2>&1 || { echo "error: $HOSTCC (host compiler) not found" >&2; exit 1; }
+
+if ! echo '#include <curses.h>' | "$CC" -E -x c - >/dev/null 2>&1; then
+	echo "error: ncurses headers not found for $CC" >&2
+	exit 1
+fi
+
+if [ -z "$NCURSES_LIBS" ]; then
+	PKG_CONFIG="${CROSS}pkg-config"
+	if command -v "$PKG_CONFIG" >/dev/null 2>&1; then
+		NCURSES_LIBS="$("$PKG_CONFIG" --static --libs ncurses 2>/dev/null)" || true
+	fi
+	NCURSES_LIBS="${NCURSES_LIBS:--lncurses}"
+fi
+
+mkdir -p "$BUILDDIR"
+
+"$HOSTCC" -Wall -O2 -o "$BUILDDIR/makehelp" makehelp.c
+"$BUILDDIR/makehelp" help.txt "$BUILDDIR/help.c"
+
+CFLAGS="-DTARGET_CURSES -I. -Wall -O3 -fomit-frame-pointer"
+SRCS="buffer.c config.c dialog.c disp.c fed.c gui.c help.c kill.c
+      line.c menu.c misc.c search.c tetris.c util.c iocurses.c"
+
+for src in $SRCS; do
+	obj="$BUILDDIR/${src%.c}.o"
+	case "$src" in
+		help.c) "$CC" $CFLAGS -c "$BUILDDIR/help.c" -o "$obj" ;;
+		*)      "$CC" $CFLAGS -c "$src" -o "$obj" ;;
+	esac
+done
+
+OBJS=""
+for src in $SRCS; do
+	OBJS="$OBJS $BUILDDIR/${src%.c}.o"
+done
+
+"$CC" -static -s -o "$BUILDDIR/fed" $OBJS $NCURSES_LIBS
+
+echo "Built: $BUILDDIR/fed"

--- a/ci/build-linux-arm64.sh
+++ b/ci/build-linux-arm64.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Build a static Linux ARM64 binary with ncurses.
+# Runs natively on aarch64 or cross-compiles using aarch64-linux-gnu-gcc.
+#
+# Environment variables:
+#   CROSS        - toolchain prefix        (default: aarch64-linux-gnu- when cross-compiling)
+#   CC           - target C compiler       (default: ${CROSS}gcc)
+#   HOSTCC       - host C compiler         (default: gcc)
+#   BUILDDIR     - output directory        (default: build/linux-arm64)
+#   NCURSES_LIBS - ncurses link flags      (auto-detected via pkg-config)
+set -e
+
+if [ "$(uname -m)" = "aarch64" ]; then
+	CROSS="${CROSS:-}"
+else
+	CROSS="${CROSS:-aarch64-linux-gnu-}"
+fi
+CC="${CC:-${CROSS}gcc}"
+HOSTCC="${HOSTCC:-gcc}"
+BUILDDIR="${BUILDDIR:-build/linux-arm64}"
+
+command -v "$CC" >/dev/null 2>&1 || { echo "error: $CC not found" >&2; exit 1; }
+command -v "$HOSTCC" >/dev/null 2>&1 || { echo "error: $HOSTCC (host compiler) not found" >&2; exit 1; }
+
+if ! echo '#include <curses.h>' | "$CC" -E -x c - >/dev/null 2>&1; then
+	echo "error: ncurses headers not found for $CC" >&2
+	exit 1
+fi
+
+if [ -z "$NCURSES_LIBS" ]; then
+	PKG_CONFIG="${CROSS}pkg-config"
+	if command -v "$PKG_CONFIG" >/dev/null 2>&1; then
+		NCURSES_LIBS="$("$PKG_CONFIG" --static --libs ncurses 2>/dev/null)" || true
+	fi
+	NCURSES_LIBS="${NCURSES_LIBS:--lncurses}"
+fi
+
+mkdir -p "$BUILDDIR"
+
+"$HOSTCC" -Wall -O2 -o "$BUILDDIR/makehelp" makehelp.c
+"$BUILDDIR/makehelp" help.txt "$BUILDDIR/help.c"
+
+CFLAGS="-DTARGET_CURSES -I. -Wall -O3 -fomit-frame-pointer"
+SRCS="buffer.c config.c dialog.c disp.c fed.c gui.c help.c kill.c
+      line.c menu.c misc.c search.c tetris.c util.c iocurses.c"
+
+for src in $SRCS; do
+	obj="$BUILDDIR/${src%.c}.o"
+	case "$src" in
+		help.c) "$CC" $CFLAGS -c "$BUILDDIR/help.c" -o "$obj" ;;
+		*)      "$CC" $CFLAGS -c "$src" -o "$obj" ;;
+	esac
+done
+
+OBJS=""
+for src in $SRCS; do
+	OBJS="$OBJS $BUILDDIR/${src%.c}.o"
+done
+
+"$CC" -static -s -o "$BUILDDIR/fed" $OBJS $NCURSES_LIBS
+
+echo "Built: $BUILDDIR/fed"

--- a/ci/build-win32.sh
+++ b/ci/build-win32.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Cross-compile a Windows x86 (32-bit) binary using MinGW.
+#
+# Toolchain requirements:
+#   - i686-w64-mingw32-gcc (and optionally windres for icons)
+#
+# Environment variables:
+#   CROSS    - toolchain prefix        (default: i686-w64-mingw32-)
+#   CC       - target C compiler       (default: ${CROSS}gcc)
+#   WINDRES  - resource compiler       (default: ${CROSS}windres)
+#   HOSTCC   - host C compiler         (default: gcc)
+#   BUILDDIR - output directory        (default: build/win32)
+set -e
+
+CROSS="${CROSS:-i686-w64-mingw32-}"
+CC="${CC:-${CROSS}gcc}"
+WINDRES="${WINDRES:-${CROSS}windres}"
+HOSTCC="${HOSTCC:-gcc}"
+BUILDDIR="${BUILDDIR:-build/win32}"
+
+command -v "$CC" >/dev/null 2>&1 || { echo "error: $CC not found" >&2; exit 1; }
+command -v "$HOSTCC" >/dev/null 2>&1 || { echo "error: $HOSTCC (host compiler) not found" >&2; exit 1; }
+
+mkdir -p "$BUILDDIR"
+
+"$HOSTCC" -Wall -O2 -o "$BUILDDIR/makehelp" makehelp.c
+"$BUILDDIR/makehelp" help.txt "$BUILDDIR/help.c"
+
+CFLAGS="-DTARGET_WIN -iquote . -Wall -O3 -fomit-frame-pointer"
+SRCS="buffer.c config.c dialog.c disp.c fed.c gui.c help.c kill.c
+      line.c menu.c misc.c search.c tetris.c util.c iowin.c"
+
+for src in $SRCS; do
+	obj="$BUILDDIR/${src%.c}.o"
+	case "$src" in
+		help.c) "$CC" $CFLAGS -c "$BUILDDIR/help.c" -o "$obj" ;;
+		*)      "$CC" $CFLAGS -c "$src" -o "$obj" ;;
+	esac
+done
+
+OBJS=""
+for src in $SRCS; do
+	OBJS="$OBJS $BUILDDIR/${src%.c}.o"
+done
+
+if command -v "$WINDRES" >/dev/null 2>&1 && [ -f fed.rc ]; then
+	"$WINDRES" fed.rc -o "$BUILDDIR/fed_res.o"
+	OBJS="$OBJS $BUILDDIR/fed_res.o"
+fi
+
+"$CC" -s -mwindows -o "$BUILDDIR/fed.exe" $OBJS \
+	-luser32 -lgdi32 -lshell32 -lwinmm -ladvapi32
+
+echo "Built: $BUILDDIR/fed.exe"

--- a/ci/package-dos.sh
+++ b/ci/package-dos.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Package the MS-DOS build into a .zip archive.
+#
+# Environment variables:
+#   BUILDDIR - build output directory  (default: build/dos)
+#   DISTDIR  - package output directory (default: dist)
+set -e
+
+BUILDDIR="${BUILDDIR:-build/dos}"
+DISTDIR="${DISTDIR:-dist}"
+ARCHIVE="$DISTDIR/fed-dos.zip"
+
+test -f "$BUILDDIR/fed.exe" || { echo "error: $BUILDDIR/fed.exe not found; run build first" >&2; exit 1; }
+
+mkdir -p "$DISTDIR"
+
+rm -f "$ARCHIVE"
+zip -j "$ARCHIVE" "$BUILDDIR/fed.exe" readme.txt COPYING help.txt fed.syn
+
+echo "Packaged: $ARCHIVE"

--- a/ci/package-linux-arm32.sh
+++ b/ci/package-linux-arm32.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Package the Linux ARM32 build into a .tar.gz archive.
+#
+# Environment variables:
+#   BUILDDIR - build output directory  (default: build/linux-arm32)
+#   DISTDIR  - package output directory (default: dist)
+set -e
+
+BUILDDIR="${BUILDDIR:-build/linux-arm32}"
+DISTDIR="${DISTDIR:-dist}"
+ARCHIVE="$DISTDIR/fed-linux-arm32.tar.gz"
+
+test -x "$BUILDDIR/fed" || { echo "error: $BUILDDIR/fed not found; run build first" >&2; exit 1; }
+
+mkdir -p "$DISTDIR"
+
+cp readme.txt COPYING help.txt fed.syn "$BUILDDIR/"
+tar czf "$ARCHIVE" -C "$BUILDDIR" fed readme.txt COPYING help.txt fed.syn
+
+echo "Packaged: $ARCHIVE"

--- a/ci/package-linux-arm64.sh
+++ b/ci/package-linux-arm64.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Package the Linux ARM64 build into a .tar.gz archive.
+#
+# Environment variables:
+#   BUILDDIR - build output directory  (default: build/linux-arm64)
+#   DISTDIR  - package output directory (default: dist)
+set -e
+
+BUILDDIR="${BUILDDIR:-build/linux-arm64}"
+DISTDIR="${DISTDIR:-dist}"
+ARCHIVE="$DISTDIR/fed-linux-arm64.tar.gz"
+
+test -x "$BUILDDIR/fed" || { echo "error: $BUILDDIR/fed not found; run build first" >&2; exit 1; }
+
+mkdir -p "$DISTDIR"
+
+cp readme.txt COPYING help.txt fed.syn "$BUILDDIR/"
+tar czf "$ARCHIVE" -C "$BUILDDIR" fed readme.txt COPYING help.txt fed.syn
+
+echo "Packaged: $ARCHIVE"

--- a/ci/package-linux-x86_64.sh
+++ b/ci/package-linux-x86_64.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Package the Linux x86-64 build into a .tar.gz archive.
+#
+# Environment variables:
+#   BUILDDIR - build output directory  (default: build/linux-x86_64)
+#   DISTDIR  - package output directory (default: dist)
+set -e
+
+BUILDDIR="${BUILDDIR:-build/linux-x86_64}"
+DISTDIR="${DISTDIR:-dist}"
+ARCHIVE="$DISTDIR/fed-linux-x86_64.tar.gz"
+
+test -x "$BUILDDIR/fed" || { echo "error: $BUILDDIR/fed not found; run build first" >&2; exit 1; }
+
+mkdir -p "$DISTDIR"
+
+cp readme.txt COPYING help.txt fed.syn "$BUILDDIR/"
+tar czf "$ARCHIVE" -C "$BUILDDIR" fed readme.txt COPYING help.txt fed.syn
+
+echo "Packaged: $ARCHIVE"

--- a/ci/package-win32.sh
+++ b/ci/package-win32.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Package the Windows x86 (32-bit) build into a .zip archive.
+#
+# Environment variables:
+#   BUILDDIR - build output directory  (default: build/win32)
+#   DISTDIR  - package output directory (default: dist)
+set -e
+
+BUILDDIR="${BUILDDIR:-build/win32}"
+DISTDIR="${DISTDIR:-dist}"
+ARCHIVE="$DISTDIR/fed-win32.zip"
+
+test -f "$BUILDDIR/fed.exe" || { echo "error: $BUILDDIR/fed.exe not found; run build first" >&2; exit 1; }
+
+mkdir -p "$DISTDIR"
+
+rm -f "$ARCHIVE"
+zip -j "$ARCHIVE" "$BUILDDIR/fed.exe" readme.txt COPYING help.txt fed.syn
+
+echo "Packaged: $ARCHIVE"

--- a/ci/package-win64.sh
+++ b/ci/package-win64.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Package the Windows x86-64 build into a .zip archive.
+#
+# Environment variables:
+#   BUILDDIR - build output directory  (default: build/win64)
+#   DISTDIR  - package output directory (default: dist)
+set -e
+
+BUILDDIR="${BUILDDIR:-build/win64}"
+DISTDIR="${DISTDIR:-dist}"
+ARCHIVE="$DISTDIR/fed-win64.zip"
+
+test -f "$BUILDDIR/fed.exe" || { echo "error: $BUILDDIR/fed.exe not found; run build first" >&2; exit 1; }
+
+mkdir -p "$DISTDIR"
+
+rm -f "$ARCHIVE"
+zip -j "$ARCHIVE" "$BUILDDIR/fed.exe" readme.txt COPYING help.txt fed.syn
+
+echo "Packaged: $ARCHIVE"


### PR DESCRIPTION
  add CI packaging scripts for release archives

  Add CI build scripts scripts for linux-arm64, linux-arm32, and
  win32. (in addition to the existing dos, win64, linux-x86_64 build
  scripts)

  Add ci/package-*.sh to create distributable archives containing the
  binary, readme.txt, COPYING, help.txt, and fed.syn. Linux produces a
  .tar.gz, Windows and DOS produce .zip files.

  Update the GitHub Actions workflow to run packaging after each build
  and upload the archives as artifacts instead of bare binaries.

  Update GitHub Actions workflow with QEMU-based ARM jobs,
  win32 job, and a release job triggered by release-* tags using CalVer.

  Supported builds:
  - DOS
  - Linux-x86_64
  - Linux-arm64 (aarch64)
  - Linux-arm32 (armhf)
  - Win64
  - Win32

  Add BUILDING.txt documenting native and cross-compilation for all
  supported targets.

  Use ${CROSS}gcc and ${CROSS}pkg-config so the scripts work both
  natively (in Alpine containers) and as cross-compiles from x86-64
  using aarch64-linux-gnu- and arm-linux-gnueabihf- toolchains.
